### PR TITLE
Feature/Resize UI

### DIFF
--- a/Engine/src/Core/DX11App.cpp
+++ b/Engine/src/Core/DX11App.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "DX11App.h"
-
+#include "RenderTargetMgr.h"
 
 void DX11App::SetWireframes()
 {
@@ -223,6 +223,9 @@ bool DX11App::Resize(UINT new_x, UINT new_y)
     view_port.TopLeftX = 0.0f;
     view_port.TopLeftY = 0.0f;
     dx11_context.Get()->RSSetViewports(1, &view_port);
+
+    // UI 랜더타겟 리사이즈
+    reality::RENDER_TARGET->LoadRT("UI")->Resize((float)new_x, (float)new_y);
 
     return true;
 }

--- a/Engine/src/Core/DX11App.h
+++ b/Engine/src/Core/DX11App.h
@@ -54,7 +54,6 @@ private:
     DirectX::CommonStates*         dx_states;
 
     D3D11_VIEWPORT                 view_port;
-
 };
 
 

--- a/Engine/src/Core/Engine.cpp
+++ b/Engine/src/Core/Engine.cpp
@@ -42,8 +42,25 @@ LRESULT CALLBACK WindowProc(
 }
 
 namespace reality {
-	bool Engine::OnInit(HINSTANCE hinstance, LPCWSTR title, POINT screen_size)
+	bool Engine::OnInit(HINSTANCE hinstance, LPCWSTR title, E_Resolution resolution)
 	{
+		POINT screen_size = { 0, 0 };
+		
+		current_resolution = resolution;
+
+		switch (resolution)
+		{
+		case E_Resolution::R1920x1080:
+			screen_size = { 1920, 1080 };
+			break;
+		case E_Resolution::R1280x720:
+			screen_size = { 1280, 720 };
+			break;
+		default:
+			screen_size = { 1920, 1080 };
+			break;
+		}
+
 		// À©µµ¿ì ÃÊ±âÈ­
 		if (InitWindow(hinstance, title, screen_size) == false)
 			return false;
@@ -109,13 +126,45 @@ namespace reality {
 		DX11APP->OnRelease();
 	}
 
+	void Engine::Resize(E_Resolution new_resolution)
+	{
+		POINT screen_size = { 0, 0 };
+
+		current_resolution = new_resolution;
+
+		switch (new_resolution)
+		{
+		case E_Resolution::R1920x1080:
+			screen_size = { 1920, 1080 };
+			break;
+		case E_Resolution::R1280x720:
+			screen_size = { 1280, 720 };
+			break;
+		default:
+			screen_size = { 1920, 1080 };
+			break;
+		}
+
+		SetWindowPos(hwnd, NULL, 0, 0, screen_size.x, screen_size.y, SWP_NOMOVE | SWP_NOZORDER | SWP_FRAMECHANGED);
+
+		RECT new_rc;
+		GetClientRect(hwnd, &new_rc);
+		wnd_size.x = new_rc.right - new_rc.left;
+		wnd_size.y = new_rc.bottom - new_rc.top;
+
+		DX11APP->Resize(wnd_size.x, wnd_size.y);
+	}
+
 	bool Engine::InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT screen_size)
 	{
 		this->hinstance = hinstance;
 		this->title = title;
 
+		auto style = WS_OVERLAPPEDWINDOW;
+		style &= ~WS_THICKFRAME;
+
 		RECT rc = { 0, 0, screen_size.x, screen_size.y };
-		AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, false);
+		AdjustWindowRect(&rc, style, false);
 		this->wnd_size.x = rc.right - rc.left;
 		this->wnd_size.y = rc.bottom - rc.top;
 
@@ -135,7 +184,7 @@ namespace reality {
 		hwnd = CreateWindow(
 			window_class.lpszClassName,
 			title,
-			WS_OVERLAPPEDWINDOW,
+			style,
 			GetSystemMetrics(SM_CXSCREEN) / 2 - wnd_size.x / 2,
 			GetSystemMetrics(SM_CYSCREEN) / 2 - wnd_size.y / 2,
 			wnd_size.x, wnd_size.y,

--- a/Engine/src/Core/Engine.cpp
+++ b/Engine/src/Core/Engine.cpp
@@ -152,6 +152,8 @@ namespace reality {
 		wnd_size.x = new_rc.right - new_rc.left;
 		wnd_size.y = new_rc.bottom - new_rc.top;
 
+		E_Resolution_Size[new_resolution] = { wnd_size.x, wnd_size.y };
+
 		DX11APP->Resize(wnd_size.x, wnd_size.y);
 	}
 

--- a/Engine/src/Core/Engine.h
+++ b/Engine/src/Core/Engine.h
@@ -1,7 +1,7 @@
 #include "DX11App.h"
-#include "UI.h"
 
 namespace reality {
+
 	enum E_Resolution
 	{
 		R1920x1080 = 0,
@@ -10,6 +10,8 @@ namespace reality {
 	};
 
 	static const string E_Resolution_String[] = { "1920 X 1080", "1280 X 720" };
+	static POINT  E_Resolution_Size[] = { { 1920, 1061 }, { 1264, 681 } };
+	static const float  E_Resolution_Multiply[] = { 1.0f, 2.0f / 3.0f };
 
 	class DLL_API Engine
 	{
@@ -23,14 +25,6 @@ namespace reality {
 		void OnRelease();
 		void Resize(E_Resolution new_resolution);
 
-	public:
-		POINT			GetWindowSize() { return wnd_size; }
-		HINSTANCE		GetInstanceHandle() { return hinstance; }
-		HWND			GetWindowHandle() { return hwnd; }
-		E_Resolution	GetWindowResolution() { return current_resolution; }
-	private:
-		bool InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT screen_size);
-
 	private:
 		HINSTANCE		hinstance;
 		LPCWSTR			title;
@@ -38,6 +32,13 @@ namespace reality {
 		POINT			wnd_size;
 		E_Resolution    current_resolution;
 
+	public:
+		POINT			GetWindowSize() { return wnd_size; }
+		HINSTANCE		GetInstanceHandle() { return hinstance; }
+		HWND			GetWindowHandle() { return hwnd; }
+		E_Resolution	GetWindowResolution() { return current_resolution; }
+	private:
+		bool InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT screen_size);
 	};
 }
 

--- a/Engine/src/Core/Engine.h
+++ b/Engine/src/Core/Engine.h
@@ -1,30 +1,42 @@
 #include "DX11App.h"
+#include "UI.h"
 
 namespace reality {
+	enum E_Resolution
+	{
+		R1920x1080 = 0,
+		R1280x720 = 1,
+		RESOLUTION_COUNT,
+	};
+
+	static const string E_Resolution_String[] = { "1920 X 1080", "1280 X 720" };
+
 	class DLL_API Engine
 	{
 		SINGLETON(Engine)
 #define ENGINE reality::Engine::GetInst()
 
 	public:
-		bool OnInit(HINSTANCE hinstance, LPCWSTR title, POINT screen_size);
+		bool OnInit(HINSTANCE hinstance, LPCWSTR title, E_Resolution resolution);
 		void Run();
 		void OnResized();
 		void OnRelease();
+		void Resize(E_Resolution new_resolution);
 
 	public:
-		POINT     GetWindowSize() { return wnd_size; }
-		HINSTANCE GetInstanceHandle() { return hinstance; }
-		HWND      GetWindowHandle() { return hwnd; }
-
+		POINT			GetWindowSize() { return wnd_size; }
+		HINSTANCE		GetInstanceHandle() { return hinstance; }
+		HWND			GetWindowHandle() { return hwnd; }
+		E_Resolution	GetWindowResolution() { return current_resolution; }
 	private:
 		bool InitWindow(HINSTANCE hinstance, LPCWSTR title, POINT screen_size);
 
 	private:
-		HINSTANCE hinstance;
-		LPCWSTR   title;
-		HWND      hwnd;
-		POINT     wnd_size;
+		HINSTANCE		hinstance;
+		LPCWSTR			title;
+		HWND			hwnd;
+		POINT			wnd_size;
+		E_Resolution    current_resolution;
 
 	};
 }

--- a/Engine/src/Managers/RenderTargetMgr.cpp
+++ b/Engine/src/Managers/RenderTargetMgr.cpp
@@ -27,7 +27,7 @@ bool RenderTarget::Create(float width, float height)
 	return false;
 }
 
-void RenderTarget::CreateRenderData()
+void RenderTarget::CreateRenderData() 
 {
 	rect_.SetRectByCenter({ ENGINE->GetWindowSize().x / 2.0f, ENGINE->GetWindowSize().y / 2.0f }, ENGINE->GetWindowSize().x, ENGINE->GetWindowSize().y);
 
@@ -231,6 +231,8 @@ void RenderTarget::Resize(float width, float height)
 
 	width_ = width;
 	height_ = height;
+
+	rect_.SetRectByCenter({ ENGINE->GetWindowSize().x / 2.0f, ENGINE->GetWindowSize().y / 2.0f }, ENGINE->GetWindowSize().x, ENGINE->GetWindowSize().y);
 
 	SetViewPort();
 

--- a/Engine/src/Managers/RenderTargetMgr.h
+++ b/Engine/src/Managers/RenderTargetMgr.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Components.h"
+#include "UI.h"
 
 namespace reality
 {
@@ -9,8 +9,8 @@ namespace reality
 		float								width_;
 		float								height_;
 	public:
-		ID3D11RenderTargetView*				render_target_view_;
-		ID3D11DepthStencilView*				depth_stencil_view_;
+		ComPtr<ID3D11RenderTargetView>		render_target_view_;
+		ComPtr<ID3D11DepthStencilView>		depth_stencil_view_;
 	public:
 		ComPtr<ID3D11Texture2D>				render_target_view_texture_;
 		ComPtr<ID3D11Texture2D>				depth_stencil_view_texture_;
@@ -43,6 +43,7 @@ namespace reality
 	public:
 		bool		SetRenderTarget();
 		void		RenderingRT();
+		void		Resize(float width, float height);
 	private:
 		void		CreateRenderData();
 	};

--- a/Engine/src/Systems/UISystem.cpp
+++ b/Engine/src/Systems/UISystem.cpp
@@ -39,6 +39,10 @@ void UISystem::OnCreate(entt::registry& reg)
 
 void UISystem::OnUpdate(entt::registry& reg)
 {
+	auto current_rt = RENDER_TARGET->LoadRT("UI");
+	if (render_target_.get() != current_rt.get())
+		render_target_ = current_rt;
+
 	// UI 랜더타겟으로 변경 후 UI들 랜더링
 	render_target_->SetRenderTarget();
 	
@@ -48,8 +52,6 @@ void UISystem::OnUpdate(entt::registry& reg)
 		C_UI& ui_comp = reg.get<C_UI>(entity);
 		for (auto& pair : ui_comp.ui_list)
 		{
-			if (!pair.second->GetOnOff())
-				continue;
 			pair.second->Update();
 		}
 
@@ -62,8 +64,8 @@ void UISystem::OnUpdate(entt::registry& reg)
 	// 백버퍼에 UI 랜더타겟 랜더링
 	float scale_x = render_target_->rect_.width / ENGINE->GetWindowSize().x;
 	float scale_y = render_target_->rect_.height / ENGINE->GetWindowSize().y;
-	float pos_x = render_target_->rect_.center.x / ENGINE->GetWindowSize().x;
-	float pos_y = render_target_->rect_.center.y / ENGINE->GetWindowSize().y;
+	float pos_x = 0.5f;
+	float pos_y = 0.5f;
 
 	
 	XMMATRIX s = XMMatrixScaling(scale_x, scale_y, 1.0f);

--- a/Engine/src/Systems/UISystem.cpp
+++ b/Engine/src/Systems/UISystem.cpp
@@ -51,8 +51,6 @@ void UISystem::OnUpdate(entt::registry& reg)
 			if (!pair.second->GetOnOff())
 				continue;
 			pair.second->Update();
-			if (&reg != &SCENE_MGR->GetRegistry())
-				return;
 		}
 
 		for (auto& pair : ui_comp.ui_list)

--- a/Engine/src/UI/UIBase.cpp
+++ b/Engine/src/UI/UIBase.cpp
@@ -188,8 +188,14 @@ void UIBase::UpdateRectTransform()
 
 void UIBase::AddChildUI(shared_ptr<UIBase> child_ui)
 {
-	child_ui_list_.push_back(child_ui);
+	child_ui_list_.insert(child_ui);
 	child_ui->parent_ui_ = this;
+}
+
+void reality::UIBase::DeleteChildUI(shared_ptr<UIBase> child_ui)
+{
+	child_ui_list_.erase(child_ui);
+	child_ui->parent_ui_ = nullptr;
 }
 
 E_UIState UIBase::GetCurrentState()

--- a/Engine/src/UI/UIBase.cpp
+++ b/Engine/src/UI/UIBase.cpp
@@ -1,7 +1,6 @@
 ﻿#include "stdafx.h"
 #include "UIBase.h"
 #include "Engine.h"
-#include "DX11App.h"
 #include "ResourceMgr.h"
 #include "UISystem.h"
 
@@ -12,6 +11,7 @@ void UIBase::Init()
 	current_state_ = E_UIState::UI_NORMAL;
 	On();
 	CreateRenderData();
+	rect_transform_.resize(E_Resolution::RESOLUTION_COUNT);
 }
 
 void UIBase::Update()
@@ -100,7 +100,8 @@ void UIBase::UpdateThisUI()
 void UIBase::RenderThisUI()
 {
 	// Set Constant Buffer
-	UISystem::SetCbData(XMMatrixTranspose(rect_transform_.world_matrix));
+	auto resolution = ENGINE->GetWindowResolution();
+	UISystem::SetCbData(XMMatrixTranspose(rect_transform_[resolution].world_matrix));
 
 	// Set Topology
 	DX11APP->GetDeviceContext()->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
@@ -147,43 +148,48 @@ void UIBase::RenderThisUI()
 
 void UIBase::UpdateRectTransform()
 {
-	// 부모 UI가 있으면 부모 UI의 좌표계에서 계산
-	if (parent_ui_ != NULL)
+	//auto resolution = ENGINE->GetWindowResolution();
+	for (int i = 0; i < E_Resolution::RESOLUTION_COUNT; i++)
 	{
-		XMFLOAT2 world_min = {
-			rect_transform_.local_rect.min.x + parent_ui_->rect_transform_.world_rect.min.x,
-			rect_transform_.local_rect.min.y + parent_ui_->rect_transform_.world_rect.min.y,
-		};
+		// 부모 UI가 있으면 부모 UI의 좌표계에서 계산
+		if (parent_ui_ != NULL)
+		{
+			XMFLOAT2 world_min = {
+				rect_transform_[i].local_rect.min.x + parent_ui_->rect_transform_[i].world_rect.min.x,
+				rect_transform_[i].local_rect.min.y + parent_ui_->rect_transform_[i].world_rect.min.y,
+			};
 
-		rect_transform_.world_rect.SetRectByMin(world_min, rect_transform_.local_rect.width, rect_transform_.local_rect.height);
+			rect_transform_[i].world_rect.SetRectByMin(world_min, rect_transform_[i].local_rect.width, rect_transform_[i].local_rect.height);
 
-		float scale_x = rect_transform_.world_rect.width / ENGINE->GetWindowSize().x;
-		float scale_y = rect_transform_.world_rect.height / ENGINE->GetWindowSize().y;
-		float pos_x = rect_transform_.world_rect.center.x / ENGINE->GetWindowSize().x;
-		float pos_y = rect_transform_.world_rect.center.y / ENGINE->GetWindowSize().y;
+			float scale_x = rect_transform_[i].world_rect.width / E_Resolution_Size[i].x;  //ENGINE->GetWindowSize().x;
+			float scale_y = rect_transform_[i].world_rect.height / E_Resolution_Size[i].y; //ENGINE->GetWindowSize().y;
+			float pos_x = rect_transform_[i].world_rect.center.x / E_Resolution_Size[i].x; //ENGINE->GetWindowSize().x;
+			float pos_y = rect_transform_[i].world_rect.center.y / E_Resolution_Size[i].y; //ENGINE->GetWindowSize().y;
 
-		XMMATRIX s = XMMatrixScaling(scale_x, scale_y, 1.0f);
-		XMMATRIX r = XMMatrixRotationZ(0.0f);
-		XMMATRIX t = XMMatrixTranslation(pos_x, pos_y, 0.0f);
+			XMMATRIX s = XMMatrixScaling(scale_x, scale_y, 1.0f);
+			XMMATRIX r = XMMatrixRotationZ(0.0f);
+			XMMATRIX t = XMMatrixTranslation(pos_x, pos_y, 0.0f);
 
-		rect_transform_.world_matrix = s * r * t;
+			rect_transform_[i].world_matrix = s * r * t;
+		}
+		else
+		{
+			float scale_x = rect_transform_[i].local_rect.width / E_Resolution_Size[i].x;  // ENGINE->GetWindowSize().x;
+			float scale_y = rect_transform_[i].local_rect.height / E_Resolution_Size[i].y; // ENGINE->GetWindowSize().y;
+			float pos_x = rect_transform_[i].local_rect.center.x / E_Resolution_Size[i].x; // ENGINE->GetWindowSize().x;
+			float pos_y = rect_transform_[i].local_rect.center.y / E_Resolution_Size[i].y; // ENGINE->GetWindowSize().y;
+
+			XMMATRIX s = XMMatrixScaling(scale_x, scale_y, 1.0f);
+			XMMATRIX r = XMMatrixRotationZ(0.0f);
+			XMMATRIX t = XMMatrixTranslation(pos_x, pos_y, 0.0f);
+
+			rect_transform_[i].local_matrix = s * r * t;
+
+			rect_transform_[i].world_rect = rect_transform_[i].local_rect;
+			rect_transform_[i].world_matrix = rect_transform_[i].local_matrix;
+		}
 	}
-	else
-	{
-		float scale_x = rect_transform_.local_rect.width / ENGINE->GetWindowSize().x;
-		float scale_y = rect_transform_.local_rect.height / ENGINE->GetWindowSize().y;
-		float pos_x = rect_transform_.local_rect.center.x / ENGINE->GetWindowSize().x;
-		float pos_y = rect_transform_.local_rect.center.y / ENGINE->GetWindowSize().y;
-
-		XMMATRIX s = XMMatrixScaling(scale_x, scale_y, 1.0f);
-		XMMATRIX r = XMMatrixRotationZ(0.0f);
-		XMMATRIX t = XMMatrixTranslation(pos_x, pos_y, 0.0f);
-
-		rect_transform_.local_matrix = s * r * t;
-
-		rect_transform_.world_rect = rect_transform_.local_rect;
-		rect_transform_.world_matrix = rect_transform_.local_matrix;
-	}
+	
 }
 
 void UIBase::AddChildUI(shared_ptr<UIBase> child_ui)
@@ -224,46 +230,88 @@ bool UIBase::GetOnOff()
 
 void UIBase::SetLocalRectByMin(XMFLOAT2 min, float width, float height)
 {
-	rect_transform_.local_rect.min = min;
-	rect_transform_.local_rect.width = width;
-	rect_transform_.local_rect.height = height;
-	rect_transform_.local_rect.max = { min.x + width, min.y + height };
-	rect_transform_.local_rect.center = { min.x + width / 2.0f, min.y + height / 2.0f };
+	for (int i = 0; i < E_Resolution::RESOLUTION_COUNT; i++)
+	{
+		float resolution_multiply = E_Resolution_Multiply[i];
+		XMFLOAT2 resolution_min = { min.x * resolution_multiply, min.y * resolution_multiply };
+		ComputeLocalRectByMin((E_Resolution)i, resolution_min, width * resolution_multiply, height * resolution_multiply);
+	}
 
 	UpdateRectTransform();
 }
 
 void UIBase::SetLocalRectByMax(XMFLOAT2 max, float width, float height)
 {
-	rect_transform_.local_rect.max = max;
-	rect_transform_.local_rect.width = width;
-	rect_transform_.local_rect.height = height;
-	rect_transform_.local_rect.min = { max.x - width, max.y - height };
-	rect_transform_.local_rect.center = { max.x - width / 2.0f, max.y - height / 2.0f };
+	for (int i = 0; i < E_Resolution::RESOLUTION_COUNT; i++)
+	{
+		float resolution_multiply = E_Resolution_Multiply[i];
+		XMFLOAT2 resolution_max = { max.x * resolution_multiply, max.y * resolution_multiply };
+		ComputeLocalRectByMax((E_Resolution)i, resolution_max, width * resolution_multiply, height * resolution_multiply);
+	}
 
 	UpdateRectTransform();
 }
 
 void UIBase::SetLocalRectByCenter(XMFLOAT2 center, float width, float height)
 {
-	rect_transform_.local_rect.center = center;
-	rect_transform_.local_rect.width = width;
-	rect_transform_.local_rect.height = height;
-	rect_transform_.local_rect.min = { center.x - width / 2.0f, center.y - height / 2.0f };
-	rect_transform_.local_rect.max = { center.x + width / 2.0f, center.y + height / 2.0f };
+	for (int i = 0; i < E_Resolution::RESOLUTION_COUNT; i++)
+	{
+		float resolution_multiply = E_Resolution_Multiply[i];
+		XMFLOAT2 resolution_center = { center.x * resolution_multiply, center.y * resolution_multiply };
+		ComputeLocalRectByCenter((E_Resolution)i, resolution_center, width * resolution_multiply, height * resolution_multiply);
+	}
 
 	UpdateRectTransform();
 }
 
 void UIBase::SetLocalRectByMinMax(XMFLOAT2 min, XMFLOAT2 max)
 {
-	rect_transform_.local_rect.min = min;
-	rect_transform_.local_rect.max = max;
-	rect_transform_.local_rect.width = max.x - min.x;
-	rect_transform_.local_rect.height = max.y - min.y;
-	rect_transform_.local_rect.center = { min.x + (rect_transform_.local_rect.width / 2.0f), min.y + (rect_transform_.local_rect.height / 2.0f) };
+	for (int i = 0; i < E_Resolution::RESOLUTION_COUNT; i++)
+	{
+		float resolution_multiply = E_Resolution_Multiply[i];
+		XMFLOAT2 resolution_min = { min.x * resolution_multiply, min.y * resolution_multiply };
+		XMFLOAT2 resolution_max = { max.x * resolution_multiply, max.y * resolution_multiply };
+		ComputeLocalRectByMinMax((E_Resolution)i, resolution_min, resolution_max);
+	}
 
 	UpdateRectTransform();
+}
+
+void UIBase::ComputeLocalRectByMin(E_Resolution resolution, XMFLOAT2 min, float width, float height)
+{
+	rect_transform_[resolution].local_rect.min = min;
+	rect_transform_[resolution].local_rect.width = width;
+	rect_transform_[resolution].local_rect.height = height;
+	rect_transform_[resolution].local_rect.max = { min.x + width, min.y + height };
+	rect_transform_[resolution].local_rect.center = { min.x + width / 2.0f, min.y + height / 2.0f };
+}
+
+void UIBase::ComputeLocalRectByMax(E_Resolution resolution, XMFLOAT2 max, float width, float height)
+{
+	rect_transform_[resolution].local_rect.max = max;
+	rect_transform_[resolution].local_rect.width = width;
+	rect_transform_[resolution].local_rect.height = height;
+	rect_transform_[resolution].local_rect.min = { max.x - width, max.y - height };
+	rect_transform_[resolution].local_rect.center = { max.x - width / 2.0f, max.y - height / 2.0f };
+}
+
+void UIBase::ComputeLocalRectByCenter(E_Resolution resolution, XMFLOAT2 center, float width, float height)
+{
+	rect_transform_[resolution].local_rect.center = center;
+	rect_transform_[resolution].local_rect.width = width;
+	rect_transform_[resolution].local_rect.height = height;
+	rect_transform_[resolution].local_rect.min = { center.x - width / 2.0f, center.y - height / 2.0f };
+	rect_transform_[resolution].local_rect.max = { center.x + width / 2.0f, center.y + height / 2.0f };
+}
+
+void UIBase::ComputeLocalRectByMinMax(E_Resolution resolution, XMFLOAT2 min, XMFLOAT2 max)
+{
+	rect_transform_[resolution].local_rect.min = min;
+	rect_transform_[resolution].local_rect.max = max;
+	rect_transform_[resolution].local_rect.width = max.x - min.x;
+	rect_transform_[resolution].local_rect.height = max.y - min.y;
+	rect_transform_[resolution].local_rect.center =
+	{ min.x + (rect_transform_[resolution].local_rect.width / 2.0f), min.y + (rect_transform_[resolution].local_rect.height / 2.0f) };
 }
 
 

--- a/Engine/src/UI/UIBase.h
+++ b/Engine/src/UI/UIBase.h
@@ -9,8 +9,8 @@ namespace reality
 		bool						onoff_;
 		E_UIState					current_state_;
 	public:
-		UIBase*						parent_ui_;
-		vector<shared_ptr<UIBase>>	child_ui_list_;
+		UIBase*								parent_ui_;
+		unordered_set<shared_ptr<UIBase>>	child_ui_list_;
 	public:
 		RectTransform	rect_transform_;
 		RectRenderData	render_data_;
@@ -27,6 +27,7 @@ namespace reality
 		void UpdateRectTransform();
 	public:
 		void AddChildUI(shared_ptr<UIBase> child_ui);
+		void DeleteChildUI(shared_ptr<UIBase> child_ui);
 		E_UIState GetCurrentState();
 		void SetCurrentState(E_UIState state);
 	public:

--- a/Engine/src/UI/UIBase.h
+++ b/Engine/src/UI/UIBase.h
@@ -3,16 +3,18 @@
 
 namespace reality
 {
+	enum E_Resolution;
+
 	class DLL_API UIBase
 	{
 	protected:
-		bool						onoff_;
-		E_UIState					current_state_;
+		bool		onoff_;
+		E_UIState	current_state_;
 	public:
 		UIBase*								parent_ui_;
 		unordered_set<shared_ptr<UIBase>>	child_ui_list_;
 	public:
-		RectTransform	rect_transform_;
+		vector<RectTransform> rect_transform_;
 		RectRenderData	render_data_;
 	protected:
 		virtual void Init();
@@ -39,6 +41,11 @@ namespace reality
 		virtual void SetLocalRectByMax(XMFLOAT2 max, float width, float height);
 		virtual void SetLocalRectByCenter(XMFLOAT2 center, float width, float height);
 		virtual void SetLocalRectByMinMax(XMFLOAT2 min, XMFLOAT2 max);
+	private:
+		virtual void ComputeLocalRectByMin(E_Resolution resolution, XMFLOAT2 min, float width, float height);
+		virtual void ComputeLocalRectByMax(E_Resolution resolution, XMFLOAT2 max, float width, float height);
+		virtual void ComputeLocalRectByCenter(E_Resolution resolution, XMFLOAT2 center, float width, float height);
+		virtual void ComputeLocalRectByMinMax(E_Resolution resolution, XMFLOAT2 min, XMFLOAT2 max);
 	};
 }
 

--- a/Engine/src/UI/UI_Button.cpp
+++ b/Engine/src/UI/UI_Button.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "UI_Button.h"
+#include "Engine.h"
 #include "InputMgr.h"
 
 using namespace reality;
@@ -38,7 +39,10 @@ bool UI_Button::MouseOnButton(const Rect& button_rect, const POINT& mouse_point)
 
 void UI_Button::UpdateButtonState()
 {
-	if (MouseOnButton(rect_transform_.world_rect, DINPUT->GetMousePosition()))
+	if (!onoff_)
+		return;
+	auto resolution = ENGINE->GetWindowResolution();
+	if (MouseOnButton(rect_transform_[resolution].world_rect, DINPUT->GetMousePosition()))
 	{
 		current_state_ = E_UIState::UI_HOVER;
 		if (DINPUT->GetMouseState(L_BUTTON) == KeyState::KEY_PUSH || DINPUT->GetMouseState(L_BUTTON) == KeyState::KEY_HOLD)

--- a/Engine/src/UI/UI_Button.cpp
+++ b/Engine/src/UI/UI_Button.cpp
@@ -8,11 +8,11 @@ using namespace reality;
 void UI_Button::InitButton(string normal, string hover, string push, string select, string disable)
 {
 	UIBase::Init();
-	button_texture_list.insert({ E_UIState::UI_NORMAL, normal });
-	button_texture_list.insert({ E_UIState::UI_HOVER, hover });
-	button_texture_list.insert({ E_UIState::UI_PUSH, push });
-	button_texture_list.insert({ E_UIState::UI_SELECT, select });
-	button_texture_list.insert({ E_UIState::UI_DISABLED, disable });
+	button_texture_list[E_UIState::UI_NORMAL] = normal;
+	button_texture_list[E_UIState::UI_HOVER] = hover;
+	button_texture_list[E_UIState::UI_PUSH] = push;
+	button_texture_list[E_UIState::UI_SELECT] = select;
+	button_texture_list[E_UIState::UI_DISABLED] = disable;
 }
 
 void UI_Button::Update()
@@ -49,6 +49,10 @@ void UI_Button::UpdateButtonState()
 		{
 			current_state_ = E_UIState::UI_SELECT;
 		}
+	}
+	else if (current_state_ == E_UIState::UI_PUSH && DINPUT->GetMouseState(L_BUTTON) == KeyState::KEY_HOLD)
+	{
+		current_state_ = E_UIState::UI_PUSH;
 	}
 	else
 	{

--- a/Engine/src/UI/UI_Listbox.cpp
+++ b/Engine/src/UI/UI_Listbox.cpp
@@ -1,0 +1,185 @@
+#include "stdafx.h"
+#include "UI_Listbox.h"
+#include "InputMgr.h"
+
+using namespace reality;
+
+
+void UI_Listbox::InitListBox(string open_panel, 
+	string closed_normal,	string opened_normal,
+	string closed_hover,	string opened_hover,
+	string closed_push,		string opened_push,
+	string closed_select,	string opened_select,
+	string closed_disable,	string opened_disable)
+{
+	UI_Button::Init();
+
+	current_item_text_ = make_shared<UI_Text>();
+	current_item_text_->InitText("", E_Font::ROTUNDA, { 0.0f, 10.0f });
+	AddChildUI(current_item_text_);
+
+	open_panel_ = make_shared<UI_Image>();
+	open_panel_->InitImage(open_panel);
+	InitButton(closed_normal, closed_hover, closed_push, closed_select, closed_disable);
+
+	list_button_textures.insert({ "closed_normal", closed_normal });
+	list_button_textures.insert({ "closed_hover", closed_hover });
+	list_button_textures.insert({ "closed_push", closed_push });
+	list_button_textures.insert({ "closed_select", closed_select });
+	list_button_textures.insert({ "closed_disable", closed_disable });
+
+	list_button_textures.insert({ "opened_normal", opened_normal });
+	list_button_textures.insert({ "opened_hover", opened_hover });
+	list_button_textures.insert({ "opened_push", opened_push });
+	list_button_textures.insert({ "opened_select", opened_select });
+	list_button_textures.insert({ "opened_disable", opened_disable });
+}
+
+void reality::UI_Listbox::InitItemButton(XMFLOAT2 min, float width, float height, float height_space, string normal, string hover, string push, string select, string disable)
+{
+	item_button_min_ = min;
+	item_button_width_ = width;
+	item_button_height_ = height; 
+	item_button_height_space_ = height_space;
+
+	item_button_textures[E_UIState::UI_NORMAL] = normal;
+	item_button_textures[E_UIState::UI_HOVER] = hover;
+	item_button_textures[E_UIState::UI_PUSH] = push;
+	item_button_textures[E_UIState::UI_SELECT] = select;
+	item_button_textures[E_UIState::UI_DISABLED] = disable;
+}
+
+void reality::UI_Listbox::SetOpenPanelLocalRectByMin(XMFLOAT2 min, float width, float height)
+{
+	open_panel_->SetLocalRectByMin(min, width, height);
+}
+void reality::UI_Listbox::SetOpenPanelLocalRectByMax(XMFLOAT2 max, float width, float height)
+{
+	open_panel_->SetLocalRectByMax(max, width, height);
+}
+void reality::UI_Listbox::SetOpenPanelLocalRectByCenter(XMFLOAT2 center, float width, float height)
+{
+	open_panel_->SetLocalRectByCenter(center, width, height);
+}
+void reality::UI_Listbox::SetOpenPanelLocalRectByMinMax(XMFLOAT2 min, XMFLOAT2 max)
+{
+	open_panel_->SetLocalRectByMinMax(min, max);
+}
+
+void UI_Listbox::Update()
+{
+	UI_Button::Update();
+
+	if (current_state_ == E_UIState::UI_SELECT)
+	{
+		open_ = !open_;
+		if (open_)
+			OpenListBox();
+		else
+			CloseListBox();
+	}
+
+	if (!open_)
+		return;
+
+	// if Opened, Item Selecting continue
+	for (int i = 0; i < item_button_list_.size(); i++)
+	{
+		if (item_button_list_[i]->GetCurrentState() == E_UIState::UI_SELECT)
+		{
+			item_button_list_[i]->SetCurrentState(E_UIState::UI_NORMAL);
+			selected_item_num_ = i;
+			SetListBoxText(item_list_[selected_item_num_]);
+			open_ = !open_;
+			CloseListBox();
+			break;
+		}
+	}
+}
+
+
+string UI_Listbox::GetItem()
+{
+	return item_list_[selected_item_num_];
+}
+void UI_Listbox::SetItemSelected(int index)
+{
+	if (index >= item_list_.size())
+		return;
+	else
+	{
+		selected_item_num_ = index;
+		SetListBoxText(item_list_[selected_item_num_]);
+	}
+}
+void UI_Listbox::SetItemSelected(string value)
+{
+	auto iter = find(item_list_.begin(), item_list_.end(), value);
+	if (iter == item_list_.end())
+		return;
+	else
+	{
+		for (int i = 0; i < item_list_.size(); i++)
+		{
+			if (value == item_list_[i])
+			{
+				selected_item_num_ = i;
+				SetListBoxText(item_list_[selected_item_num_]);
+			}
+		}
+	}
+}
+void UI_Listbox::AddItem(string value)
+{
+	item_list_.push_back(value);
+
+	item_button_list_.push_back({ make_shared<UI_Button>() });
+	auto new_item_button = item_button_list_[item_button_list_.size() - 1];
+	new_item_button->InitButton(
+		item_button_textures[E_UIState::UI_NORMAL],
+		item_button_textures[E_UIState::UI_HOVER],
+		item_button_textures[E_UIState::UI_PUSH],
+		item_button_textures[E_UIState::UI_SELECT],
+		item_button_textures[E_UIState::UI_DISABLED]
+	);
+	open_panel_->AddChildUI(new_item_button);
+	XMFLOAT2 min = { item_button_min_.x, item_button_min_.y + item_button_height_space_ * (item_button_list_.size() - 1) };
+	new_item_button->SetLocalRectByMin(min,	item_button_width_, item_button_height_);
+
+	auto new_item_text = make_shared<UI_Text>();
+	new_item_text->InitText(value, E_Font::ROTUNDA, {0.0f, 10.0f});
+	new_item_button->AddChildUI(new_item_text);
+}
+
+void UI_Listbox::OpenListBox()
+{
+	// Button Texture Change
+	InitButton(
+		list_button_textures["opened_normal"], 
+		list_button_textures["opened_hover"], 
+		list_button_textures["opened_push"],
+		list_button_textures["opened_select"], 
+		list_button_textures["opened_disable"]);
+	
+	// Add OpenPanel to child 
+	AddChildUI(open_panel_);
+}
+void UI_Listbox::CloseListBox()
+{
+	// Button Texture Change
+	InitButton(
+		list_button_textures["closed_normal"], 
+		list_button_textures["closed_hover"], 
+		list_button_textures["closed_push"], 
+		list_button_textures["closed_select"], 
+		list_button_textures["closed_disable"]);
+
+	// Delete OpenPanel to child
+	DeleteChildUI(open_panel_);
+}
+
+void reality::UI_Listbox::SetListBoxText(string text)
+{
+	current_item_text_->InitText(text, E_Font::ROTUNDA, { 5.0f, 20.0f });
+}
+

--- a/Engine/src/UI/UI_Listbox.cpp
+++ b/Engine/src/UI/UI_Listbox.cpp
@@ -98,9 +98,21 @@ void UI_Listbox::Update()
 }
 
 
-string UI_Listbox::GetItem()
+string UI_Listbox::GetCurrentItem()
 {
 	return item_list_[selected_item_num_];
+}
+int UI_Listbox::GetCurrentIndex()
+{
+	return selected_item_num_;
+}
+string UI_Listbox::GetItem(int index)
+{
+	return item_list_[index];
+}
+string UI_Listbox::GetItem(string value)
+{
+	return *find(item_list_.begin(), item_list_.end(), value);
 }
 void UI_Listbox::SetItemSelected(int index)
 {

--- a/Engine/src/UI/UI_Listbox.cpp
+++ b/Engine/src/UI/UI_Listbox.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "UI_Listbox.h"
+#include "Engine.h"
 #include "InputMgr.h"
 
 using namespace reality;
@@ -15,7 +16,7 @@ void UI_Listbox::InitListBox(string open_panel,
 	UI_Button::Init();
 
 	current_item_text_ = make_shared<UI_Text>();
-	current_item_text_->InitText("", E_Font::ROTUNDA, { 0.0f, 10.0f });
+		current_item_text_->InitText("", E_Font::ROTUNDA, { 0.0f, 10.0f });
 	AddChildUI(current_item_text_);
 
 	open_panel_ = make_shared<UI_Image>();
@@ -156,7 +157,7 @@ void UI_Listbox::AddItem(string value)
 	);
 	open_panel_->AddChildUI(new_item_button);
 	XMFLOAT2 min = { item_button_min_.x, item_button_min_.y + item_button_height_space_ * (item_button_list_.size() - 1) };
-	new_item_button->SetLocalRectByMin(min,	item_button_width_, item_button_height_);
+	new_item_button->SetLocalRectByMin(min, item_button_width_, item_button_height_);
 
 	auto new_item_text = make_shared<UI_Text>();
 	new_item_text->InitText(value, E_Font::ROTUNDA, {0.0f, 10.0f});
@@ -192,6 +193,6 @@ void UI_Listbox::CloseListBox()
 
 void reality::UI_Listbox::SetListBoxText(string text)
 {
-	current_item_text_->InitText(text, E_Font::ROTUNDA, { 5.0f, 20.0f });
+	current_item_text_->SetText(text);
 }
 

--- a/Engine/src/UI/UI_Listbox.h
+++ b/Engine/src/UI/UI_Listbox.h
@@ -1,0 +1,54 @@
+#pragma once
+#include "UI_Image.h"
+#include "UI_Button.h"
+#include "UI_Text.h"
+
+namespace reality
+{
+	class DLL_API UI_Listbox : public UI_Button
+	{
+	private:
+		unordered_map<string, string>	 list_button_textures;
+	private:
+		unordered_map<E_UIState, string> item_button_textures;
+		XMFLOAT2	item_button_min_;
+		float		item_button_width_;
+		float		item_button_height_;
+		float		item_button_height_space_;
+		int			selected_item_num_;
+	private:
+		bool	open_ = false;
+	private:
+		vector<string>					item_list_;
+		vector<shared_ptr<UI_Button>>	item_button_list_;
+	private:
+		shared_ptr<UI_Image>	open_panel_;
+		shared_ptr<UI_Text>		current_item_text_;
+	public:
+		void InitListBox(string open_panel, string closed_normal, string opened_normal, 
+			string closed_hover = "", string opened_hover = "",
+			string closed_push = "", string opened_push = "",
+			string closed_select = "", string opened_select = "",
+			string closed_disable = "", string opened_disable = "");
+
+		void InitItemButton(XMFLOAT2 min, float width, float height, float height_space, string normal, string hover, string push =" ", string select = "", string disable = "");
+
+		void SetOpenPanelLocalRectByMin	(XMFLOAT2 min, float width, float height);
+		void SetOpenPanelLocalRectByMax	(XMFLOAT2 max, float width, float height);
+		void SetOpenPanelLocalRectByCenter(XMFLOAT2 center, float width, float height);
+		void SetOpenPanelLocalRectByMinMax(XMFLOAT2 min, XMFLOAT2 max);
+	public:
+		virtual void Update() override;
+	public:
+		void	AddItem(string value);
+		string	GetItem();
+		void	SetItemSelected(int index);
+		void	SetItemSelected(string value);
+	private:
+		void	OpenListBox();
+		void	CloseListBox();
+		void	SetListBoxText(string text);
+	};
+}
+
+

--- a/Engine/src/UI/UI_Listbox.h
+++ b/Engine/src/UI/UI_Listbox.h
@@ -41,7 +41,10 @@ namespace reality
 		virtual void Update() override;
 	public:
 		void	AddItem(string value);
-		string	GetItem();
+		string	GetCurrentItem();
+		int		GetCurrentIndex();
+		string	GetItem(int index);
+		string	GetItem(string value);
 		void	SetItemSelected(int index);
 		void	SetItemSelected(string value);
 	private:

--- a/Engine/src/UI/UI_Slider.cpp
+++ b/Engine/src/UI/UI_Slider.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "UI_Slider.h"
+#include "Engine.h"
 #include "InputMgr.h"
 
 using namespace reality;
@@ -26,13 +27,14 @@ void UI_Slider::UpdateSliderPos()
 {
 	if (slider_->GetCurrentState() == E_UIState::UI_PUSH)
 	{
-		float x = (float)DINPUT->GetMousePosition().x - rect_transform_.world_rect.min.x;
+		auto resolution = ENGINE->GetWindowResolution();
+		float x = (float)DINPUT->GetMousePosition().x - rect_transform_[resolution].world_rect.min.x;
 		x = max(x, 0.0f);
-		x = min(x, rect_transform_.world_rect.width);
-		slider_->SetLocalRectByCenter({ x, rect_transform_.world_rect.height / 2.0f }, 
-			slider_->rect_transform_.world_rect.width, slider_->rect_transform_.world_rect.height);
+		x = min(x, rect_transform_[resolution].world_rect.width);
+		slider_->SetLocalRectByCenter({ x * 1.0f / E_Resolution_Multiply[resolution], rect_transform_[E_Resolution::R1920x1080].world_rect.height / 2.0f},
+			slider_->rect_transform_[E_Resolution::R1920x1080].world_rect.width, slider_->rect_transform_[E_Resolution::R1920x1080].world_rect.height);
 
-		value_ = 100.0f * x / rect_transform_.world_rect.min.x;
+		value_ = 100.0f * x / rect_transform_[resolution].world_rect.min.x;
 	}
 }
 
@@ -43,5 +45,5 @@ float UI_Slider::GetValue()
 
 void UI_Slider::SetSliderLocalRect(float width, float height)
 {
-	slider_->SetLocalRectByCenter({ rect_transform_.world_rect.width / 2.0f, rect_transform_.world_rect.height / 2.0f }, width, height);
+	slider_->SetLocalRectByCenter({ rect_transform_[E_Resolution::R1920x1080].world_rect.width / 2.0f, rect_transform_[E_Resolution::R1920x1080].world_rect.height / 2.0f }, width, height);
 }

--- a/Engine/src/UI/UI_Text.cpp
+++ b/Engine/src/UI/UI_Text.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "UI_Text.h"
+#include "Engine.h"
 
 using namespace reality;
 
@@ -25,5 +26,6 @@ void UI_Text::SetFont(E_Font font)
 
 void UI_Text::RenderThisUI()
 {
-	WRITER->Draw(text_, font_, rect_transform_.world_rect.min, size_, color_);
+	auto resolution = ENGINE->GetWindowResolution();
+	WRITER->Draw(text_, font_, rect_transform_[resolution].world_rect.min, size_ * E_Resolution_Multiply[resolution], color_);
 }


### PR DESCRIPTION
- 윈도우 창 보더라인을 통해 사이즈 조정 불가능하게 설정
- 옵션 바에서 해상도를 선택하면 그 사이즈에 맞게 랜더타겟과 윈도우 크기가 변경
- 해상도마다 곱셈 상수를 설정해서 1920으로 설정한 UI RectTransform 값들을 해상도에 맞게 설정하게 구현